### PR TITLE
TOML requires quotes around version numbers

### DIFF
--- a/em/README.md
+++ b/em/README.md
@@ -53,7 +53,7 @@ fn main() {
 
 You can use Emu in your Rust projects by doing the following-
 
-1. Add `em = 0.3.0` to `Cargo.toml`
+1. Add `em = "0.3.0"` to `Cargo.toml`
 2. Confirm that an OpenCL library [is installed]() for your platform
 
 Learn how to get started with Emu by looking at [the documentation](https://docs.rs/em).


### PR DESCRIPTION
Without quotes around version numbers in a TOML file, i.e. `em = 0.3.0`, Cargo gives the error `expected newline, found a period at line 10 column 9`. crates.io always uses quotes, and adding the quotes solves the problem. 

The usage instructions should be copy-pastable, and thus, should also use quotes.