### PR TITLE
Fix compile failure issues #27 and #36

### DIFF
--- a/emu_macro/Cargo.toml
+++ b/emu_macro/Cargo.toml
@@ -16,8 +16,8 @@ edition = "2018"
 
 [dependencies]
 proc-macro2 = "0.4.30"
-syn = { version = "1.0.5", features = ["full", "visit", "fold"] }
-quote = "1.0.2"
+syn = { version = "=1.0.5", features = ["full", "visit", "fold"] }
+quote = "^1.0.3"
 
 [dev-dependencies]
 em = { path = "../em", version = "0.*" }

--- a/emu_macro/src/accelerating.rs
+++ b/emu_macro/src/accelerating.rs
@@ -120,7 +120,7 @@ impl Fold for Accelerator {
                         // is it load? read? launch?
                         if path
                             .path
-                            .is_ident(&Ident::new("load", quote::__rt::Span::call_site()))
+                            .is_ident(&Ident::new("load", quote::__private::Span::call_site()))
                         {
                             let new_code = quote! {
                                 {
@@ -166,7 +166,7 @@ impl Fold for Accelerator {
                             new_ast
                         } else if path
                             .path
-                            .is_ident(&Ident::new("read", quote::__rt::Span::call_site()))
+                            .is_ident(&Ident::new("read", quote::__private::Span::call_site()))
                         {
                             let new_code = quote! {
                                 {
@@ -190,7 +190,7 @@ impl Fold for Accelerator {
                             new_ast
                         } else if path
                             .path
-                            .is_ident(&Ident::new("launch", quote::__rt::Span::call_site()))
+                            .is_ident(&Ident::new("launch", quote::__private::Span::call_site()))
                         {
                             self.ready_to_launch = true;
 
@@ -256,7 +256,7 @@ impl Fold for Accelerator {
 
                 // (b) generate arguments
                 let args = code_generator.params.iter().map(|param| {
-                    let ident = Ident::new(&param.name, quote::__rt::Span::call_site());
+                    let ident = Ident::new(&param.name, quote::__private::Span::call_site());
                     let ident_literal = ident.to_string().clone();
 
                     if param.is_array {


### PR DESCRIPTION
```
Bumped crate quote from ^1.0.2 to ^1.0.3
Replaced quote::__rt with quote::__private
Changed crate syn from ^1.0.5 to =1.0.5
```

I was trying out a bunch of GPU-computing crates when I encountered Emu (well, the older version, or crate `em`, as outlined in the discussion under issue #31). It's very intuitive and I love it, except it doesn't compile. After reading the discussion under #27, #31, and #36, I made some modifications to the `dev` branch, as outlined above. It compiles fine for now.